### PR TITLE
Change command to full path for Go/json error.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,4 +42,4 @@ data:
   image: postgres:latest
   volumes:
     - /var/lib/postgresql
-  command: true
+  command: /bin/true


### PR DESCRIPTION
Was getting an error that kept image from building:

```
json: cannot unmarshal bool into Go value of type string
```

Changed `true` to `/bin/true` per [this comment](https://realpython.com/blog/python/django-development-with-docker-compose-and-machine/#comment-2153822566).
