### PR TITLE
quotes around "true" to fix error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,4 +42,4 @@ data:
   image: postgres:latest
   volumes:
     - /var/lib/postgresql
-  command: true
+  command: "true"


### PR DESCRIPTION
I see the following error when trying to do docker-compose up.

Creating dockerizingdjango_data_1...
json: cannot unmarshal bool into Go value of type string

Putting quotes around -true- resolved the issue
