### PR TITLE
Adding quotes around true to fix error

### DIFF
--- a/production.yml
+++ b/production.yml
@@ -40,4 +40,4 @@ data:
   image: postgres:latest
   volumes:
     - /var/lib/postgresql
-  command: true
+  command: "true"


### PR DESCRIPTION
When trying to run this example the production.yml I noticed the following error: 

`json: cannot unmarshal bool into Go value of type string`

Fix: changing the last line of the production.yml to read: 

`command: "true"`
