### PR TITLE
14 debug enabled in production yaml settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 venv
 env
 __pycache__
+.venv
+.cache

--- a/web/docker_django/settings.py
+++ b/web/docker_django/settings.py
@@ -23,7 +23,7 @@ SITE_ROOT = os.path.dirname(os.path.realpath(__file__))
 SECRET_KEY = os.environ['SECRET_KEY']
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True if os.getenv('DEBUG') == 'true' else False
+DEBUG = os.getenv('DEBUG', 'NO').lower() in ('on', 'true', 'y', 'yes')
 
 ALLOWED_HOSTS = ['*']
 

--- a/web/tests/test_env_settings.py
+++ b/web/tests/test_env_settings.py
@@ -1,0 +1,38 @@
+"""Test Environmental settings are handled properly."""
+
+
+import os
+import importlib
+from unittest.mock import patch
+# from django.test import TestCase
+# from unittest import skip
+# we have to use tools outside of django, because when it's initialized
+# it's too late to change environment variables
+from unittest import TestCase, main
+
+
+class DebugSettingTest(TestCase):
+    """Test if setting DEBUG is handled properly."""
+
+    _variants = {
+        True: ('Yes', 'YES', 'Y', 'TRUE', 'tRUE', 'true', 'On'),
+
+        False: ('No', 'nO', 'N', 'n', 'false', 'False', 'off', 'oFF'),
+    }
+    env_var_debug = 'DEBUG'
+
+    def test_debug_setting(self):
+        """Check if config accepts environment variable DEBUG and sets it."""
+        from docker_django import settings
+        for result, words in self._variants.items():
+            for word in words:
+                # print(word, result)
+                with patch.dict('os.environ', {self.env_var_debug: word}):
+                    importlib.reload(settings)
+                    assert self.env_var_debug in os.environ
+                    self.assertEqual(settings.DEBUG, result)
+                assert self.env_var_debug not in os.environ  # should be True
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
[+] Accept all types of "true" setting available in json: on, yes, true, yes to set a DEBUG setting in settings.py. To enable DEBUG mode just set it in docker-compose.yml in section web/environment/DEBUG.
[+] Test to ensure environment variable DEBUG is being handled properly.