### PR TITLE
Add missing static files volume for web container in production

### DIFF
--- a/production.yml
+++ b/production.yml
@@ -6,6 +6,8 @@ web:
   links:
     - postgres:postgres
     - redis:redis
+  volumes:
+    - /usr/src/app/static
   env_file: .env
   command: /usr/local/bin/gunicorn docker_django.wsgi:application -w 2 -b :8000
 


### PR DESCRIPTION
When using `production.yml` file for build, the `main.css` file will be missing, because the Django static path is not exposed in volume for `nginx`.

The `web` container should expose static files path as a volume, so `nginx` container can use it as per configuration.

```nginx
# nginx/sites_enabled/django_project
location /static {
    alias /usr/src/app/static;
}
```